### PR TITLE
Potential fix for code scanning alert no. 138: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/vendor/bundle/ruby/2.6.0/gems/sassc-2.4.0/test/test_helper.rb
+++ b/vendor/bundle/ruby/2.6.0/gems/sassc-2.4.0/test/test_helper.rb
@@ -12,7 +12,7 @@ module FixtureHelper
   FIXTURE_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "fixtures"))
 
   def fixture(path)
-    IO.read(fixture_path(path))
+    File.read(fixture_path(path))
   end
 
   def fixture_path(path)


### PR DESCRIPTION
Potential fix for [https://github.com/bunbutterjam/bunbutterjam.github.io/security/code-scanning/138](https://github.com/bunbutterjam/bunbutterjam.github.io/security/code-scanning/138)

General fix: replace `IO` file-reading class methods with their `File` equivalents when reading local files from variable paths.

Best fix here (single, minimal change): in `vendor/bundle/ruby/2.6.0/gems/sassc-2.4.0/test/test_helper.rb`, update `fixture` so it uses `File.read(fixture_path(path))` instead of `IO.read(...)`. This preserves behavior for local file reads and addresses the CodeQL finding directly.

No new imports, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
